### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/python/lsst/donut/analysis.py
+++ b/python/lsst/donut/analysis.py
@@ -58,7 +58,7 @@ class SelectionAnalysisTask(pipeBase.CmdLineTask):
     def __init__(self, *args, **kwargs):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
-    def run(self, sensorRef):
+    def runDataRef(self, sensorRef):
         dataId = sensorRef.dataId
         visit = dataId['visit']
         ccd = dataId['ccd']
@@ -144,7 +144,7 @@ class GoodnessOfFitAnalysisTask(pipeBase.CmdLineTask):
     def __init__(self, *args, **kwargs):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
-    def run(self, sensorRef):
+    def runDataRef(self, sensorRef):
         dataId = sensorRef.dataId
         visit = dataId['visit']
         ccd = dataId['ccd']
@@ -216,7 +216,7 @@ class FitParamAnalysisTask(pipeBase.CmdLineTask):
     def __init__(self, *args, **kwargs):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
-    def run(self, expRef, butler):
+    def runDataRef(self, expRef, butler):
         """Process a single exposure, with scatter-gather-scatter using MPI.
         """
         dataIdList = dict([(ccdRef.get("ccdExposureId"), ccdRef.dataId)
@@ -305,7 +305,7 @@ class StampCcdAnalysisTask(pipeBase.CmdLineTask):
     def __init__(self, *args, **kwargs):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
-    def run(self, expRef, butler):
+    def runDataRef(self, expRef, butler):
         """Make a stamp analysis image for a single exposure, binned by CCD.
         """
         dataIdList = dict([(ccdRef.get("ccdExposureId"), ccdRef.dataId)
@@ -461,7 +461,7 @@ class StampAnalysisTask(pipeBase.CmdLineTask):
     def __init__(self, *args, **kwargs):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
-    def run(self, expRef, butler):
+    def runDataRef(self, expRef, butler):
         """Make a stamp analysis image for a single exposure
         """
         dataIdList = dict([(ccdRef.get("ccdExposureId"), ccdRef.dataId)

--- a/python/lsst/donut/donutDriver.py
+++ b/python/lsst/donut/donutDriver.py
@@ -61,7 +61,7 @@ class DonutDriverTask(BatchParallelTask):
         self.ignoreCcds = set(self.config.ignoreCcdList)
         self.makeSubtask("fitDonut")
 
-    def run(self, sensorRef):
+    def runDataRef(self, sensorRef):
         """Fit a single CCD box of donuts, with scatter-gather-scatter
         using MPI.
         """
@@ -71,4 +71,4 @@ class DonutDriverTask(BatchParallelTask):
             return None
 
         with self.logOperation("processing %s" % (sensorRef.dataId,)):
-            return self.fitDonut.run(sensorRef)
+            return self.fitDonut.runDataRef(sensorRef)

--- a/python/lsst/donut/fitDonut.py
+++ b/python/lsst/donut/fitDonut.py
@@ -130,7 +130,7 @@ class FitDonutConfig(pexConfig.Config):
 
 
 class FitDonutTask(pipeBase.CmdLineTask):
-    """!Fit a donut images with a wavefront forward model.
+    """!Fit donut images with a wavefront forward model.
 
     @anchor FitDonutTask_
 
@@ -141,10 +141,10 @@ class FitDonutTask(pipeBase.CmdLineTask):
 
     @section donut_FitDonut_IO  Invoking the Task
 
-    This task is normallly invokable as a CmdLineTask, though it can also be
-    invoked as a subtask using the `run` method, in which case a sensorRef and
-    optionally that reference's `icSrc` and `icExp` datasets should be passed
-    as arguments.
+    This task is normallly invokable as a CmdLineTask, though it can
+    also be invoked as a subtask using the `runDataRef` method, in
+    which case a sensorRef and optionally that reference's `icSrc` and
+    `icExp` datasets should be passed as arguments.
 
     @section donut_FitDonut_Config  Configuration parameters
 
@@ -262,7 +262,7 @@ class FitDonutTask(pipeBase.CmdLineTask):
             self.keyDicts.append(keyDict)
 
     @pipeBase.timeMethod
-    def run(self, sensorRef, icSrc=None, icExp=None):
+    def runDataRef(self, sensorRef, icSrc=None, icExp=None):
         """!Fit donuts
         """
         if icSrc is None:

--- a/python/lsst/donut/pair_analysis.py
+++ b/python/lsst/donut/pair_analysis.py
@@ -56,7 +56,7 @@ class ZernikeParamAnalysisTask(PairBaseTask):
     def __init__(self, *args, **kwargs):
         PairBaseTask.__init__(self, *args, **kwargs)
 
-    def run(self, extraRef, intraRef=None):
+    def runDataRef(self, extraRef, intraRef=None):
         """Process a pair of exposures.
         """
         extraVisit = extraRef.dataId['visit']
@@ -128,7 +128,7 @@ class PairStampCcdAnalysisTask(PairBaseTask):
     def __init__(self, *args, **kwargs):
         PairBaseTask.__init__(self, *args, **kwargs)
 
-    def run(self, extraRef, intraRef=None):
+    def runDataRef(self, extraRef, intraRef=None):
         """Process a pair of exposures.  Producing output binned by CCD.
         """
         extraVisit = extraRef.dataId['visit']
@@ -250,7 +250,7 @@ class PairStampAnalysisTask(PairBaseTask):
     def __init__(self, *args, **kwargs):
         PairBaseTask.__init__(self, *args, **kwargs)
 
-    def run(self, extraRef, intraRef=None):
+    def runDataRef(self, extraRef, intraRef=None):
         """Process a pair of exposures.
         """
         extraVisit = extraRef.dataId['visit']
@@ -397,7 +397,7 @@ class PairZernikePyramidTask(PairBaseTask):
     def __init__(self, *args, **kwargs):
         PairBaseTask.__init__(self, *args, **kwargs)
 
-    def run(self, extraRef, intraRef=None):
+    def runDataRef(self, extraRef, intraRef=None):
         extraVisit = extraRef.dataId['visit']
         self.log.info("Working on extra/intra visits: {}/{}".format(
             extraRef.dataId['visit'], intraRef.dataId['visit']))

--- a/python/lsst/donut/triplet_analysis.py
+++ b/python/lsst/donut/triplet_analysis.py
@@ -59,7 +59,7 @@ class TripletWhiskerTask(TripletBaseTask):
     def __init__(self, *args, **kwargs):
         TripletBaseTask.__init__(self, *args, **kwargs)
 
-    def run(self, focalRef, extraRef=None, intraRef=None):
+    def runDataRef(self, focalRef, extraRef=None, intraRef=None):
         """Process an exposure triplet consisting of an in-focus exposure, an
         extra-focal exposure, and an intra-focal exposure.
         """


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
